### PR TITLE
Redesign `ClassDef.field()`

### DIFF
--- a/fluentcst/__init__.py
+++ b/fluentcst/__init__.py
@@ -32,10 +32,6 @@ class RawNode(FluentCstNode):
         return self._node
 
 
-class Assign(FluentCstNode):
-    pass
-
-
 class String(FluentCstNode):
     """SimpleString for now only."""
 

--- a/fluentcst/__init__.py
+++ b/fluentcst/__init__.py
@@ -4,7 +4,7 @@ Reference:
 * https://github.com/lensvol/astboom
 """
 
-from typing import overload
+from typing import overload, Literal
 
 import libcst as cst
 from typing_extensions import Self
@@ -223,17 +223,22 @@ class ClassDef(FluentCstNode):
         | list[RawNode]
         | Dict
         | Attribute
-        | RawNode,
+        | RawNode
+        | None = None,
+        type: str | None = None,
     ) -> Self:
-        value_node = _value(value)
-        field_node = cst.SimpleStatementLine(
-            body=[
-                cst.Assign(
-                    targets=[cst.AssignTarget(target=cst.Name(value=name))],
-                    value=value_node.to_cst(),
-                )
-            ]
-        )
+        if type:
+            assign = cst.AnnAssign(
+                target=cst.Name(value=name), annotation=Annotation(type).to_cst()
+            )
+        else:
+            assert value is not None, "None is not yet supported"
+            value_node = _value(value)
+            assign = cst.Assign(
+                targets=[cst.AssignTarget(target=cst.Name(value=name))],
+                value=value_node.to_cst(),
+            )
+        field_node = cst.SimpleStatementLine(body=[assign])
         self._fields.append(field_node)
 
         return self

--- a/fluentcst/__init__.py
+++ b/fluentcst/__init__.py
@@ -219,7 +219,8 @@ class ClassDef(FluentCstNode):
 
     def field(
         self,
-        **kwargs: str
+        name: str,
+        value: str
         | Call
         | dict
         | list[str | Call]
@@ -228,17 +229,16 @@ class ClassDef(FluentCstNode):
         | Attribute
         | RawNode,
     ) -> Self:
-        for k, v in kwargs.items():
-            value_node = _value(v)
-            field_node = cst.SimpleStatementLine(
-                body=[
-                    cst.Assign(
-                        targets=[cst.AssignTarget(target=cst.Name(value=k))],
-                        value=value_node.to_cst(),
-                    )
-                ]
-            )
-            self._fields.append(field_node)
+        value_node = _value(value)
+        field_node = cst.SimpleStatementLine(
+            body=[
+                cst.Assign(
+                    targets=[cst.AssignTarget(target=cst.Name(value=name))],
+                    value=value_node.to_cst(),
+                )
+            ]
+        )
+        self._fields.append(field_node)
 
         return self
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -4,7 +4,7 @@ import fluentcst as fcst
 
 
 def test_field_can_be_fluent_dict():
-    code = fcst.ClassDef("Cls1").field(f1=fcst.Dict().element("d1", "v1")).to_code()
+    code = fcst.ClassDef("Cls1").field("f1", fcst.Dict().element("d1", "v1")).to_code()
     assert code == dedent(
         """\
         class Cls1:
@@ -14,7 +14,9 @@ def test_field_can_be_fluent_dict():
 
 
 def test_field_can_be_nested_dicts():
-    code = fcst.ClassDef("Cls1").field(f1={"d1": "v1", "d2": {"d2.1": "v1"}}).to_code()
+    code = (
+        fcst.ClassDef("Cls1").field("f1", {"d1": "v1", "d2": {"d2.1": "v1"}}).to_code()
+    )
     assert code == dedent(
         """\
         class Cls1:
@@ -26,7 +28,7 @@ def test_field_can_be_nested_dicts():
 def test_field_can_be_attribute_with_bitor():
     code = (
         fcst.ClassDef("Cls1")
-        .field(data=fcst.Attribute("BaseCls.data").bitor({"a": "b"}))
+        .field("data", fcst.Attribute("BaseCls.data").bitor({"a": "b"}))
         .to_code()
     )
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -38,3 +38,13 @@ def test_field_can_be_attribute_with_bitor():
             data = BaseCls.data | {"a": "b"}
     """
     )
+
+
+def test_field_with_only_type_declaration():
+    code = fcst.ClassDef("Cls1").field("f1", type="int").to_code()
+    assert code == dedent(
+        """\
+        class Cls1:
+            f1: int
+    """
+    )

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -6,8 +6,8 @@ import fluentcst as fcst
 def test_multiple_classes():
     module = (
         fcst.Module()
-        .add(fcst.ClassDef("Cls1").field(f1="v1"))
-        .add(fcst.ClassDef("Cls2").field(f1="v1"))
+        .add(fcst.ClassDef("Cls1").field("f1", "v1"))
+        .add(fcst.ClassDef("Cls2").field("f1", "v1"))
     )
 
     assert module.to_code() == dedent(


### PR DESCRIPTION
Allows to define the field with type hints.