### PR TITLE
Support `ClassDef` with a base class containing attributes.

### DIFF
--- a/fluentcst/__init__.py
+++ b/fluentcst/__init__.py
@@ -281,7 +281,14 @@ class ClassDef(FluentCstNode):
         return self
 
     def to_cst(self) -> cst.ClassDef:
-        bases = [cst.Arg(value=cst.Name(value=base_cls)) for base_cls in self._bases]
+        bases = [
+            cst.Arg(
+                value=Attribute(base_cls).to_cst()
+                if "." in base_cls
+                else cst.Name(value=base_cls)
+            )
+            for base_cls in self._bases
+        ]
         return cst.ClassDef(
             name=cst.Name(value=self._name),
             body=cst.IndentedBlock(body=self._fields),

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -68,3 +68,23 @@ def test_field_with_untyped_list():
             f1: list
     """
     )
+
+
+def test_class_with_base_class():
+    code = fcst.ClassDef("Cls1").base("Base").to_code()
+    assert code == dedent(
+        """\
+        class Cls1(Base):
+            pass
+    """
+    )
+
+
+def test_class_with_base_class_containing_dot():
+    code = fcst.ClassDef("Cls1").base("module.Base").to_code()
+    assert code == dedent(
+        """\
+        class Cls1(module.Base):
+            pass
+    """
+    )


### PR DESCRIPTION
Before this modification `ClassDef("Cls1").base("module.Base").to_cst()` would raise the following error :
```
libcst._nodes.base.CSTValidationError: Name 'module.Base' is not a valid identifier.
```

In such case, we need to use an `Attribute` instead of a `Name`.